### PR TITLE
fix: Add and fix types, make namedPaths optional

### DIFF
--- a/packages/pojo-router/package.json
+++ b/packages/pojo-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pojo-router",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A react hooks library to associate metadata to a path",
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",

--- a/packages/pojo-router/src/index.tsx
+++ b/packages/pojo-router/src/index.tsx
@@ -8,11 +8,21 @@ import React, {
 import { match as matchPath, compile } from 'path-to-regexp';
 import isString from 'lodash.isstring';
 
+// We want to allow re-declaration of this by declaration merging,
+// but assume types if not defined
+
+// styled-components uses this to have theme defined.
+// https://styled-components.com/docs/api#create-a-declarations-file
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DefaultRoutePojo {}
+
+type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+
 const thrower = (v: string) => {
   throw new Error('context not set');
 };
 const InboundRouterContext = React.createContext(
-  thrower as (v: string) => string[],
+  thrower as (v: string) => AnyIfEmpty<DefaultRoutePojo>[],
 );
 const OutboundRouterContext = React.createContext({} as Record<string, any>);
 const CurrentPathContext = React.createContext('');
@@ -22,8 +32,8 @@ type NamedPath = {
   sensitive?: boolean;
   [k: string]: any;
 };
-type Route = [string, Record<string, any>];
-type Props = {
+type Route = [string, AnyIfEmpty<DefaultRoutePojo>];
+type Props<RoutePojo> = {
   children: React.ReactChild;
   namedPaths: Record<string, string | NamedPath>;
   routes: Route[];
@@ -31,13 +41,13 @@ type Props = {
   currentPath: string;
 };
 
-const PojoRouter = ({
+const PojoRouter = <T extends Record<string, any>>({
   children,
   namedPaths,
   routes,
   notFound,
   currentPath,
-}: Props) => {
+}: Props<T>) => {
   const [cachedMatches, setCachedMatches] = useState({});
 
   const normalizedRouter = useMemo(
@@ -115,18 +125,22 @@ const PojoRouter = ({
   );
 };
 
-export const useCurrentPath = (...args) => {
+export const useCurrentPath = () => {
   return useContext(CurrentPathContext);
 };
 
-export const useMatches = (pathToMatch) => {
+export const useMatches = (pathToMatch: string) => {
   const allMatches = useContext(InboundRouterContext);
   return allMatches(pathToMatch);
 };
 
-export const useFirstMatch = (pathToMatch) => useMatches(pathToMatch)[0];
+export const useFirstMatch = (pathToMatch: string) =>
+  useMatches(pathToMatch)[0];
 
-export const useBestMatch = (pathToMatch, matchComparator) => {
+export const useBestMatch = (
+  pathToMatch: string,
+  matchComparator: (s1: string, s2: string) => number,
+) => {
   const allMatches = useMatches(pathToMatch);
   allMatches.sort(matchComparator);
   return allMatches[0];
@@ -134,7 +148,7 @@ export const useBestMatch = (pathToMatch, matchComparator) => {
 
 export const useCurrentMatch = () => useFirstMatch(useCurrentPath());
 
-export const useOutboundRoute = (pathOrPathName) => {
+export const useOutboundRoute = (pathOrPathName: string) => {
   const allRoutes = useContext(OutboundRouterContext);
   const outboundRoute = allRoutes[pathOrPathName];
 

--- a/packages/pojo-router/src/index.tsx
+++ b/packages/pojo-router/src/index.tsx
@@ -18,7 +18,7 @@ export interface DefaultRoutePojo {}
 
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
-const thrower = (v: string) => {
+const thrower = () => {
   throw new Error('context not set');
 };
 const InboundRouterContext = React.createContext(
@@ -33,7 +33,7 @@ type NamedPath = {
   [k: string]: any;
 };
 type Route = [string, AnyIfEmpty<DefaultRoutePojo>];
-type Props<RoutePojo> = {
+type Props = {
   children: React.ReactChild;
   namedPaths: Record<string, string | NamedPath>;
   routes: Route[];
@@ -41,13 +41,13 @@ type Props<RoutePojo> = {
   currentPath: string;
 };
 
-const PojoRouter = <T extends Record<string, any>>({
+const PojoRouter = ({
   children,
-  namedPaths,
+  namedPaths = {},
   routes,
   notFound,
   currentPath,
-}: Props<T>) => {
+}: Props) => {
   const [cachedMatches, setCachedMatches] = useState({});
 
   const normalizedRouter = useMemo(


### PR DESCRIPTION
`InboundRouterContext` assumed that the routes were defined as strings, when really they could be anything.

Since these are defined in context, there's really no way for typescript to infer because it's type depends on the react element hierarchy.  I decided to go the route of `styled-components` and allow users to define the type `DefaultRoutePojo` by merging declaration files, so that `PojoRouter` could be typed for a whole application.

I also made `namedPaths` an optional parameter, defaulting to the empty object, because we currently have no use for it.