### PR TITLE
fix: add types build, correct notFound type, type routes as readOnly

### DIFF
--- a/packages/pojo-router/package.json
+++ b/packages/pojo-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pojo-router",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A react hooks library to associate metadata to a path",
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",

--- a/packages/pojo-router/package.json
+++ b/packages/pojo-router/package.json
@@ -6,7 +6,8 @@
     "build:lib": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist *.tsbuildinfo",
-    "build": "yarn run build:lib && yarn run build:bundle",
+    "build:types": "yarn tsc",
+    "build": "yarn run build:lib && yarn run build:types && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",
     "prepublishOnly": "yarn run build:bundle"

--- a/packages/pojo-router/src/index.tsx
+++ b/packages/pojo-router/src/index.tsx
@@ -32,12 +32,12 @@ type NamedPath = {
   sensitive?: boolean;
   [k: string]: any;
 };
-type Route = [string, AnyIfEmpty<DefaultRoutePojo>];
+type Route = readonly [string, AnyIfEmpty<DefaultRoutePojo>];
 type Props = {
   children: React.ReactChild;
   namedPaths: Record<string, string | NamedPath>;
-  routes: Route[];
-  notFound: boolean;
+  routes: readonly Route[];
+  notFound: AnyIfEmpty<DefaultRoutePojo>;
   currentPath: string;
 };
 


### PR DESCRIPTION
The `types` build script was missing from the package.json causing 0.1.1 to go up to the registry with the types from 0.1.0 which were incorrect.

I also fixed the type for `notFound`, and made `routes` a `readonly` array, so we can index into it to get specificity in application types.