### PR TITLE
fix: Use closure for cache

### DIFF
--- a/packages/pojo-router/src/index.tsx
+++ b/packages/pojo-router/src/index.tsx
@@ -1,7 +1,4 @@
-import React, {
-  useMemo,
-  useContext,
-} from 'react';
+import React, { useMemo, useContext } from 'react';
 import { match as matchPath, compile } from 'path-to-regexp';
 import isString from 'lodash.isstring';
 
@@ -27,7 +24,7 @@ const CurrentPathContext = React.createContext('');
 type NamedPath = {
   path: string;
   sensitive?: boolean;
-  [k: string]: any;
+  [k: string]: unknown;
 };
 type Route = readonly [string, AnyIfEmpty<DefaultRoutePojo>];
 type Props = {
@@ -78,38 +75,34 @@ const PojoRouter = ({
     [normalizedRouter],
   );
 
+  const allMatches = useMemo(() => {
+    // cache for match lookups. Reset if routes ever change.
+    // could make this LRU if it takes up too much space.
+    const cachedMatches = {};
 
-  const allMatches = useMemo(
-    () => {
-      // cache for match lookups. Reset if routes ever change.
-      // could make this LRU if it takes up too much space.
-      const cachedMatches = {};
-
-      return (pathToMatch: string) => {
-        if (pathToMatch in cachedMatches) {
-          return cachedMatches[pathToMatch];
-        }
-
-        const allMatches = normalizedRouter.reduce(
-          (
-            acc: Record<string, any>[],
-            { matcher, values },
-          ): Record<string, any>[] => {
-            const match = matcher(pathToMatch);
-            const params = match && match.params ? match.params : {};
-            return match ? [...acc, { ...values, ...params }] : acc;
-          },
-          [],
-        );
-
-        const matches = allMatches.length === 0 ? [notFound] : allMatches;
-        cachedMatches[pathToMatch] = matches
-
-        return matches;
+    return (pathToMatch: string) => {
+      if (pathToMatch in cachedMatches) {
+        return cachedMatches[pathToMatch];
       }
-    },
-    [normalizedRouter, notFound],
-  );
+
+      const allMatches = normalizedRouter.reduce(
+        (
+          acc: Record<string, any>[],
+          { matcher, values },
+        ): Record<string, any>[] => {
+          const match = matcher(pathToMatch);
+          const params = match && match.params ? match.params : {};
+          return match ? [...acc, { ...values, ...params }] : acc;
+        },
+        [],
+      );
+
+      const matches = allMatches.length === 0 ? [notFound] : allMatches;
+      cachedMatches[pathToMatch] = matches;
+
+      return matches;
+    };
+  }, [normalizedRouter, notFound]);
 
   return (
     <InboundRouterContext.Provider value={allMatches}>
@@ -123,7 +116,7 @@ const PojoRouter = ({
 };
 PojoRouter.defaultValues = {
   namedPaths: {},
-}
+};
 
 export const useCurrentPath = () => {
   return useContext(CurrentPathContext);

--- a/packages/pojo-router/src/index.tsx
+++ b/packages/pojo-router/src/index.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo, useContext } from 'react';
 import { match as matchPath, compile } from 'path-to-regexp';
+import type {
+  ParseOptions,
+  TokensToRegexpOptions,
+  RegexpToFunctionOptions,
+} from 'path-to-regexp';
 import isString from 'lodash.isstring';
 
 // We want to allow re-declaration of this by declaration merging,
@@ -21,11 +26,9 @@ const InboundRouterContext = React.createContext(
 const OutboundRouterContext = React.createContext({} as Record<string, any>);
 const CurrentPathContext = React.createContext('');
 
-type NamedPath = {
-  path: string;
-  sensitive?: boolean;
-  [k: string]: unknown;
-};
+type NamedPath = { path: string } & ParseOptions &
+  TokensToRegexpOptions &
+  RegexpToFunctionOptions;
 type Route = readonly [string, AnyIfEmpty<DefaultRoutePojo>];
 type Props = {
   children: React.ReactChild;


### PR DESCRIPTION
It appears `setCachedMatches` and such were used to cache lookups that likely are repeated many times during render. However due to the use of state this meant every time a new match was computed, the presumably top-level PojoRouter component would trigger a re-render.

This simply uses a closure that is reset upon route changes.

Also snuck in a typing fix for namedPaths so we can avoid passing in empty pojos, which are likely to create equivalence bugs.